### PR TITLE
Fix compilation on macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ edition = "2018"
 homepage = "https://github.com/HULKs/compiled-nn-rs"
 license = "MIT"
 name = "compiled-nn"
-version = "0.6.0"
+version = "0.7.0"
 
 [dependencies]
-compiled-nn-bindings = {path = "compiled-nn-bindings", version = "0.6.0"}
+compiled-nn-bindings = {path = "compiled-nn-bindings", version = "0.7.0"}

--- a/compiled-nn-bindings/Cargo.toml
+++ b/compiled-nn-bindings/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 homepage = "https://github.com/HULKs/CompiledNN"
 license = "MIT"
 name = "compiled-nn-bindings"
-version = "0.6.0"
+version = "0.7.0"
 
 [build-dependencies]
 bindgen = "0.59.2"

--- a/compiled-nn-bindings/build.rs
+++ b/compiled-nn-bindings/build.rs
@@ -79,7 +79,7 @@ fn main() {
     let bindings = bindgen::Builder::default()
         .header("wrapper.h")
         .parse_callbacks(Box::new(bindgen::CargoCallbacks))
-        .clang_args(vec!["-x", "c++", "-I", include_path.to_str().unwrap()])
+        .clang_args(vec!["-x", "c++", "-std=c++11", "-I", include_path.to_str().unwrap()])
         .generate()
         .expect("Unable to generate bindings");
 


### PR DESCRIPTION
The macOS Apple Clang compiler seems to require an explicit `-std=c++11` argument on macOS to get `bindgen` to work correctly.

Tested the change on @knoellle 's Linux machine, worked without issues, so shouldn't break linux compilation. But prob best to test again.